### PR TITLE
Optimize 2D tensor gathering to skip sensitive layers early

### DIFF
--- a/convert_to_quant/formats/fp8_conversion.py
+++ b/convert_to_quant/formats/fp8_conversion.py
@@ -262,7 +262,9 @@ def convert_to_fp8_scaled(
         [
             key
             for key in all_keys
-            if key.endswith(".weight") and loader.get_ndim(key) == 2
+            if key.endswith(".weight")
+            and not any(avoid in key for avoid in AVOID_KEY_NAMES)
+            and loader.get_ndim(key) == 2
         ]
     )
     total_weights = len(weight_keys)


### PR DESCRIPTION
## Summary
Adds early filtering for normalization/modulation layers at the 2D tensor gathering stage (line 261)

## Problem
Currently, sensitive layers (norms, modulations, embeddings) are gathered into `weight_keys` and then filtered out later in the exclusion logic (around line 324+). This means they're loaded into memory unnecessarily

## Solution
Move common exclusion patterns up to the gathering stage using the existing `AVOID_KEY_NAMES` constant:
```python
and not any(avoid in key for avoid in AVOID_KEY_NAMES)
```
This acts as a "first line of defense" before the MODEL_FILTERS logic

## Benefits
Reduces the memory footprint of `weight_keys` list
Will avoid unnecessary downstream filtering for already-excluded layers
Complements an existing MODEL_FILTERS system
No behavioral changes